### PR TITLE
feat: add nord theme

### DIFF
--- a/lua/hardline/themes/nord.lua
+++ b/lua/hardline/themes/nord.lua
@@ -1,0 +1,128 @@
+local colors = {
+  black = {gui = '#2E3440', cterm = '235', cterm16 = '0'},
+  blue = {gui = '#5E81AC', cterm = '67', cterm16 = '12'},
+  cyan = { gui = '#88C0D0', cterm = '110', cterm16 = '14'},
+  green = {gui = '#81A1C1', cterm = '109', cterm16 = '4'},
+  grey_comment = {gui = "#4C566A", cterm = "59", cterm16 = "8"},
+  grey_cursor = {gui = "#434C5E", cterm = "59", cterm16 = "8"},
+  grey_menu = {gui = "#3B4252", cterm = "59", cterm16 = "8"},
+  purple = {gui = '#B48EAD', cterm = '139', cterm16 = '5'},
+  red = {gui = '#BF616A', cterm = '131', cterm16 = '1'},
+  white = {gui = '#D8DEE9', cterm = '188', cterm16 = '7'},
+  yellow = {gui = '#EBCB8B', cterm = '222', cterm16 = '3'},
+}
+
+local inactive = {
+  guifg = colors.grey_comment.gui,
+  guibg = colors.grey_cursor.gui,
+  ctermfg = colors.grey_comment.cterm,
+  ctermbg = colors.grey_cursor.cterm,
+}
+
+return {
+  mode = {
+    inactive = inactive,
+    normal = {
+      guifg = colors.black.gui,
+      guibg = colors.green.gui,
+      ctermfg = colors.black.cterm,
+      ctermbg = colors.green.cterm,
+    },
+    insert = {
+      guifg = colors.black.gui,
+      guibg = colors.blue.gui,
+      ctermfg = colors.black.cterm,
+      ctermbg = colors.blue.cterm,
+    },
+    replace = {
+      guifg = colors.black.gui,
+      guibg = colors.cyan.gui,
+      ctermfg = colors.black.cterm,
+      ctermbg = colors.cyan.cterm,
+    },
+    visual = {
+      guifg = colors.black.gui,
+      guibg = colors.purple.gui,
+      ctermfg = colors.black.cterm,
+      ctermbg = colors.purple.cterm,
+    },
+    command = {
+      guifg = colors.black.gui,
+      guibg = colors.red.gui,
+      ctermfg = colors.black.cterm,
+      ctermbg = colors.red.cterm,
+    },
+  },
+  low = {
+    active = {
+      guifg = colors.white.gui,
+      guibg = colors.grey_cursor.gui,
+      ctermfg = colors.white.cterm,
+      ctermbg = colors.grey_cursor.cterm,
+    },
+    inactive = inactive,
+  },
+  med = {
+    active = {
+      guifg = colors.yellow.gui,
+      guibg = colors.grey_cursor.gui,
+      ctermfg = colors.yellow.cterm,
+      ctermbg = colors.grey_cursor.cterm,
+    },
+    inactive = inactive,
+  },
+  high = {
+    active = {
+      guifg = colors.white.gui,
+      guibg = colors.grey_menu.gui,
+      ctermfg = colors.white.cterm,
+      ctermbg = colors.grey_menu.cterm,
+    },
+    inactive = inactive,
+  },
+  error = {
+    active = {
+      guifg = colors.black.gui,
+      guibg = colors.red.gui,
+      ctermfg = colors.black.cterm,
+      ctermbg = colors.red.cterm,
+    },
+    inactive = inactive,
+  },
+  warning = {
+    active = {
+      guifg = colors.black.gui,
+      guibg = colors.yellow.gui,
+      ctermfg = colors.black.cterm,
+      ctermbg = colors.yellow.cterm,
+    },
+    inactive = inactive,
+  },
+  bufferline = {
+    separator = inactive,
+    current = {
+      guifg = colors.black.gui,
+      guibg = colors.green.gui,
+      ctermfg = colors.black.cterm,
+      ctermbg = colors.green.cterm,
+    },
+    current_modified = {
+      guifg = colors.black.gui,
+      guibg = colors.blue.gui,
+      ctermfg = colors.black.cterm,
+      ctermbg = colors.blue.cterm,
+    },
+    background = {
+      guifg = colors.green.gui,
+      guibg = colors.black.gui,
+      ctermfg = colors.green.cterm,
+      ctermbg = colors.black.cterm,
+    },
+    background_modified = {
+      guifg = colors.blue.gui,
+      guibg = colors.black.gui,
+      ctermfg = colors.blue.cterm,
+      ctermbg = colors.black.cterm,
+    },
+  },
+}


### PR DESCRIPTION
Hi, Olivier

I really like nvim-hardline so that I want to add my favorite color scheme.

The colors is based on <http://nordtheme.com> and the `term16` and `term` color is converted with 
<https://gist.github.com/MicahElliott/719710>.

Here are the previews:

<img width="1208" alt="hl-normal" src="https://user-images.githubusercontent.com/1425636/107846230-12982580-6e1d-11eb-9bdf-12d3809f564c.png">
<img width="1208" alt="hl-cmd" src="https://user-images.githubusercontent.com/1425636/107846232-14fa7f80-6e1d-11eb-9919-c78620f060cf.png">
<img width="1208" alt="hl-insert" src="https://user-images.githubusercontent.com/1425636/107846234-17f57000-6e1d-11eb-9781-a06547beb6f5.png">
