### PR TITLE
Support gitsigns

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ that list is a table with the following attributes:
 |------|-------------|
 | `filename` | Filename and file status (readonly, modified, ...) |
 | `filetype` | Filetype |
-| `git` | Git hunks (requires [vim-gitgutter](https://github.com/airblade/vim-gitgutter) / [vim-signify](https://github.com/mhinz/vim-signify)) and Git branch (requires [vim-fugitive](https://github.com/tpope/vim-fugitive) / [gina.vim](https://github.com/lambdalisue/gina.vim) / [vim-branchname](https://github.com/itchyny/vim-gitbranch)) |
+| `git` | Git hunks (requires [vim-gitgutter](https://github.com/airblade/vim-gitgutter) / [vim-signify](https://github.com/mhinz/vim-signify) / [gitsigns.nvim](https://github.com/lewis6991/gitsigns.nvim)) and Git branch (requires [vim-fugitive](https://github.com/tpope/vim-fugitive) / [gina.vim](https://github.com/lambdalisue/gina.vim) / [vim-branchname](https://github.com/itchyny/vim-gitbranch) / [gitsigns.nvim](https://github.com/lewis6991/gitsigns.nvim)) |
 | `line` | Line and column positions |
 | `lsp` | Diagnostics from Neovim LSP client |
 | `mode` | Current mode |

--- a/lua/hardline/parts/git.lua
+++ b/lua/hardline/parts/git.lua
@@ -1,5 +1,6 @@
 local fn = vim.fn
 local g = vim.g
+local b = vim.b
 local fmt = string.format
 
 local function get_hunks()
@@ -11,6 +12,12 @@ local function get_hunks()
     if (summary[1] == -1) then -- signify returns {-1, -1, -1} in empty buffer
       return ''
     end
+  elseif b.gitsigns_status_dict ~= nil then
+    local status_dict = b.gitsigns_status_dict
+    if status_dict.added == nil then
+      return ''
+    end
+    summary = {status_dict.added, status_dict.changed, status_dict.removed}
   else
     return ''
   end
@@ -29,6 +36,8 @@ local function get_branch()
     branch = fn['gina#component#repo#branch']()
   elseif g.loaded_gitbranch then
     branch = fn['gitbranch#name']()
+  elseif b.gitsigns_head ~= nil then
+    branch = b.gitsigns_head
   end
   return branch ~= '' and fmt('(%s)', branch) or ''
 end


### PR DESCRIPTION
hi there, I just found that gitsigns.nvim supports both hunks and branch name features, which could replace both vim-gitgutter and vim-branchname. I am sorry for bringing multiple supports on the branch name feature (#4).

ps: gitsigns does not register variable like `g:loaded_gitsigns`, so I check directly on buf vars.