### PR TITLE
feat: add gruvbox theme

### DIFF
--- a/lua/hardline/themes/gruvbox.lua
+++ b/lua/hardline/themes/gruvbox.lua
@@ -1,0 +1,128 @@
+local colors = {
+  black = {gui = "#32302f", cterm = "236", cterm16 = "0"},
+  blue = { gui = "#83a598", cterm = "109", cterm16 = "12"},
+  cyan = {gui = "#8ec07c", cterm = "108", cterm16 = "14"},
+  green = {gui = "#b8bb26", cterm = "142", cterm16 = "10"},
+  grey_comment = {gui = "#928374", cterm = "244", cterm16 = "8"},
+  grey_cursor = {gui = "#665c54", cterm = "241", cterm16 = "8"},
+  grey_menu = {gui = "#7c6f64", cterm = "243", cterm16 = "8"},
+  purple = {gui = "#d3869b", cterm = "175", cterm16 = "13"},
+  red = {gui = "#fb4934", cterm = "167", cterm16 = "9"},
+  white = {gui = "#f2e5bc", cterm = "228", cterm16 = "15"},
+  yellow = {gui = "#fabd2f", cterm = "214", cterm16 = "11"},
+}
+
+local inactive = {
+  guifg = colors.grey_comment.gui,
+  guibg = colors.grey_cursor.gui,
+  ctermfg = colors.grey_comment.cterm,
+  ctermbg = colors.grey_cursor.cterm,
+}
+
+return {
+  mode = {
+    inactive = inactive,
+    normal = {
+      guifg = colors.black.gui,
+      guibg = colors.green.gui,
+      ctermfg = colors.black.cterm,
+      ctermbg = colors.green.cterm,
+    },
+    insert = {
+      guifg = colors.black.gui,
+      guibg = colors.blue.gui,
+      ctermfg = colors.black.cterm,
+      ctermbg = colors.blue.cterm,
+    },
+    replace = {
+      guifg = colors.black.gui,
+      guibg = colors.cyan.gui,
+      ctermfg = colors.black.cterm,
+      ctermbg = colors.cyan.cterm,
+    },
+    visual = {
+      guifg = colors.black.gui,
+      guibg = colors.purple.gui,
+      ctermfg = colors.black.cterm,
+      ctermbg = colors.purple.cterm,
+    },
+    command = {
+      guifg = colors.black.gui,
+      guibg = colors.red.gui,
+      ctermfg = colors.black.cterm,
+      ctermbg = colors.red.cterm,
+    },
+  },
+  low = {
+    active = {
+      guifg = colors.white.gui,
+      guibg = colors.grey_cursor.gui,
+      ctermfg = colors.white.cterm,
+      ctermbg = colors.grey_cursor.cterm,
+    },
+    inactive = inactive,
+  },
+  med = {
+    active = {
+      guifg = colors.yellow.gui,
+      guibg = colors.grey_cursor.gui,
+      ctermfg = colors.yellow.cterm,
+      ctermbg = colors.grey_cursor.cterm,
+    },
+    inactive = inactive,
+  },
+  high = {
+    active = {
+      guifg = colors.white.gui,
+      guibg = colors.grey_menu.gui,
+      ctermfg = colors.white.cterm,
+      ctermbg = colors.grey_menu.cterm,
+    },
+    inactive = inactive,
+  },
+  error = {
+    active = {
+      guifg = colors.black.gui,
+      guibg = colors.red.gui,
+      ctermfg = colors.black.cterm,
+      ctermbg = colors.red.cterm,
+    },
+    inactive = inactive,
+  },
+  warning = {
+    active = {
+      guifg = colors.black.gui,
+      guibg = colors.yellow.gui,
+      ctermfg = colors.black.cterm,
+      ctermbg = colors.yellow.cterm,
+    },
+    inactive = inactive,
+  },
+  bufferline = {
+    separator = inactive,
+    current = {
+      guifg = colors.black.gui,
+      guibg = colors.green.gui,
+      ctermfg = colors.black.cterm,
+      ctermbg = colors.green.cterm,
+    },
+    current_modified = {
+      guifg = colors.black.gui,
+      guibg = colors.blue.gui,
+      ctermfg = colors.black.cterm,
+      ctermbg = colors.blue.cterm,
+    },
+    background = {
+      guifg = colors.green.gui,
+      guibg = colors.black.gui,
+      ctermfg = colors.green.cterm,
+      ctermbg = colors.black.cterm,
+    },
+    background_modified = {
+      guifg = colors.blue.gui,
+      guibg = colors.black.gui,
+      ctermfg = colors.blue.cterm,
+      ctermbg = colors.black.cterm,
+    },
+  },
+}


### PR DESCRIPTION
Hello Olivier

`nvim-hardline` is awesome! I am currently using it. I would like to add support for my current colorscheme.

The colors are extracted from [`gruvbox-community/gruvbox`](https://github.com/gruvbox-community/gruvbox)
* Hex and 256 term https://github.com/gruvbox-community/gruvbox/blob/8a36e8dae3e31fa5edfb5ae91fb1c2d36b05979e/colors/gruvbox.vim#L127-L171
* 16 term https://github.com/gruvbox-community/gruvbox/blob/8a36e8dae3e31fa5edfb5ae91fb1c2d36b05979e/colors/gruvbox.vim#L272-L283

Here are the previews:
<img width="887" alt="Screen Shot 2021-04-03 at 12 44 51" src="https://user-images.githubusercontent.com/5770755/113486859-64067d80-947a-11eb-9dc9-d0046661a39a.png">
<img width="884" alt="Screen Shot 2021-04-03 at 12 45 11" src="https://user-images.githubusercontent.com/5770755/113486868-708ad600-947a-11eb-8a0a-ced58b2141e4.png">
<img width="881" alt="Screen Shot 2021-04-03 at 12 45 30" src="https://user-images.githubusercontent.com/5770755/113486873-7b456b00-947a-11eb-8cef-fca6753ba9b6.png">
<img width="883" alt="Screen Shot 2021-04-03 at 12 45 47" src="https://user-images.githubusercontent.com/5770755/113486883-85676980-947a-11eb-8509-3da158712fbf.png">
