### PR TITLE
feat: exclude terminal buffers from bufferline

### DIFF
--- a/lua/hardline.lua
+++ b/lua/hardline.lua
@@ -14,6 +14,9 @@ local cache = {}
 -------------------- OPTIONS -------------------------------
 M.options = {
   bufferline = false,
+  bufferline_settings = {
+      exclude_terminal = false,
+  },
   theme = 'default',
   sections = {
     {class = 'mode', item = require('hardline.parts.mode').get_item},
@@ -150,7 +153,7 @@ end
 -------------------- BUFFERLINE ----------------------------
 function M.update_bufferline()
   local sections = {}
-  local buffers = bufferline.get_buffers()
+  local buffers = bufferline.get_buffers(M.options.bufferline_settings)
   local separator = '|'
   for i, buffer in ipairs(buffers) do
     table.insert(sections, bufferline.to_section(buffer))

--- a/lua/hardline/bufferline.lua
+++ b/lua/hardline/bufferline.lua
@@ -1,8 +1,12 @@
 local fn, vim = vim.fn, vim
 local fmt = string.format
 
-local function is_excluded(bufnr)
-  return fn.buflisted(bufnr) == 0 or fn.getbufvar(bufnr, '&filetype') == 'qf'
+local function is_excluded(bufnr, settings)
+  local excluded = fn.buflisted(bufnr) == 0 or fn.getbufvar(bufnr, '&filetype') == 'qf'
+  if settings.exclude_terminal then
+    excluded = excluded or fn.getbufvar(bufnr, '&buftype') == 'terminal'
+  end
+  return excluded
 end
 
 local function get_head(path, tail)
@@ -58,10 +62,10 @@ local function to_section(buffer)
   }
 end
 
-local function get_buffers()
+local function get_buffers(settings)
   local buffers = {}
   for nr = 1, fn.bufnr('$') do
-    if not is_excluded(nr) then
+    if not is_excluded(nr, settings) then
       table.insert(buffers, {
         bufnr = nr,
         name = fn.fnamemodify(fn.bufname(nr), ':t'),


### PR DESCRIPTION
Hello Olivier

I am not sure if this behavior is intended or not 😬 

AFAIR in `vim-airline` the terminal buffers are not displayed in the `bufferline`, so I wanted to add a similar behavior to `nvim-hardline`

Before change:
<img width="864" alt="Screen Shot 2021-04-03 at 17 34 14" src="https://user-images.githubusercontent.com/5770755/113493351-29b1d600-94a4-11eb-8b0a-53e9be38e1a3.png">

After change:
<img width="867" alt="Screen Shot 2021-04-03 at 17 38 40" src="https://user-images.githubusercontent.com/5770755/113493355-35050180-94a4-11eb-82d7-dc507d58cb3a.png">
