### PR TITLE
feat: add option to show indexes in bufferline

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ require('hardline').setup {
     {class = 'high', item = require('hardline.parts.filetype').get_item, hide = 80},
     {class = 'mode', item = require('hardline.parts.line').get_item},
   },
+  bufferline_settings = {
+    exclude_terminal = false,  -- don't show terminal buffers in bufferline
+    show_index = false,        -- show buffer indexes (not the actual buffer numbers) in bufferline
+  },
 }
 ```
 

--- a/lua/hardline.lua
+++ b/lua/hardline.lua
@@ -16,6 +16,7 @@ M.options = {
   bufferline = false,
   bufferline_settings = {
       exclude_terminal = false,
+      show_index = false,
   },
   theme = 'default',
   sections = {
@@ -153,10 +154,11 @@ end
 -------------------- BUFFERLINE ----------------------------
 function M.update_bufferline()
   local sections = {}
-  local buffers = bufferline.get_buffers(M.options.bufferline_settings)
+  local settings = M.options.bufferline_settings
+  local buffers = bufferline.get_buffers(settings)
   local separator = '|'
   for i, buffer in ipairs(buffers) do
-    table.insert(sections, bufferline.to_section(buffer))
+    table.insert(sections, bufferline.to_section(buffer, i, settings))
     if i < #buffers then
       table.insert(sections, separator)
     end

--- a/lua/hardline/bufferline.lua
+++ b/lua/hardline/bufferline.lua
@@ -40,7 +40,7 @@ local function unique_tail(buffers)
   unique_tail(buffers)
 end
 
-local function to_section(buffer)
+local function to_section(buffer, idx, settings)
   local flags = {}
   local item = buffer.name == '' and '[No Name]' or buffer.name
   if buffer.flags.modified then
@@ -54,9 +54,14 @@ local function to_section(buffer)
   end
   flags = table.concat(flags)
   item = flags == '' and item or fmt('%s %s', item, flags)
+  if settings.show_index then
+    item = fmt(' %d:%s ', idx, item)
+  else
+    item = fmt(' %s ', item)
+  end
   return {
     class = 'bufferline',
-    item = fmt(' %s ', item),
+    item = item,
     modified = buffer.flags.modified,
     current = buffer.current,
   }


### PR DESCRIPTION
Hi there again 😃 

I am currently using another plugin to jump to the `N` opened buffer. 
So when I have two or three buffers open, I can easily jump to any of those. 
But when I have more than 6, for example, it is harder to do the count and jump. 
So I would like to display the buffer index in the `bufferline`.

By default it will be off, but it might be useful for somebody else that has a similar workflow.

And also I have updated the README adding the `bufferline_settings`

Default behavior after change:
<img width="884" alt="Screen Shot 2021-04-04 at 15 52 48" src="https://user-images.githubusercontent.com/5770755/113521242-d0a67880-955d-11eb-83de-b460ed18f400.png">

With `show_index` set as `true`
<img width="1037" alt="Screen Shot 2021-04-04 at 15 54 13" src="https://user-images.githubusercontent.com/5770755/113521267-03507100-955e-11eb-87b6-e30482b50e05.png">

