### PR TITLE
Hide trailing white space warning for markdown

### DIFF
--- a/lua/hardline/parts/whitespace.lua
+++ b/lua/hardline/parts/whitespace.lua
@@ -19,6 +19,9 @@ local function search(prefix, pattern)
 end
 
 local function check_trailing()
+  if vim.tbl_contains({'markdown'}, bo.filetype) then
+    return ''
+  end
   return search('trailing', [[\s$]])
 end
 


### PR DESCRIPTION
In the markdown syntax, it’s actually valid to have trailing spaces (it
creates a line break).

Quoting https://en.wikipedia.org/wiki/Markdown
> Two spaces at the end of a line  
> produce a line break.