### PR TITLE
add function to add LSP client names

### DIFF
--- a/lua/hardline/parts/lsp.lua
+++ b/lua/hardline/parts/lsp.lua
@@ -26,7 +26,21 @@ local function get_warning()
   return get_diagnostic('W', 'Warning')
 end
 
+local function get_lsp_clients()
+  local clients = vim.lsp.buf_get_clients()
+  if next(clients) == nil then
+    return "none"
+  end
+
+  local c = {}
+  for _, client in ipairs(clients) do
+    table.insert(c, client.name)
+  end
+  return table.concat(c, "|")
+end
+
 return {
   get_error = get_error,
   get_warning = get_warning,
+  get_lsp_clients = get_lsp_clients,
 }


### PR DESCRIPTION
Hey I thought it would be nice to show the LSP clients attached to the buffer I am currently in. I have this function locally in my dot files and thought it might maybe also be helpful to others. What do you think?

Here is a screenshot of it:
<img width="825" alt="Screenshot 2022-01-22 at 22 53 35" src="https://user-images.githubusercontent.com/5249233/150656851-417c60a5-8630-44f7-b37a-9f768af752d0.png">

