### PR TITLE
fix multi project setup get_lsp_clients

### DIFF
--- a/lua/hardline/parts/lsp.lua
+++ b/lua/hardline/parts/lsp.lua
@@ -33,7 +33,7 @@ local function get_lsp_clients()
   end
 
   local c = {}
-  for _, client in ipairs(clients) do
+  for _, client in pairs(clients) do
     table.insert(c, client.name)
   end
   return table.concat(c, "|")


### PR DESCRIPTION
The previous code actually ran into a problem, the client IDs are not continuous so, when you open a second project I ran into exactly this problem: https://github.com/neovim/neovim/issues/14618

The problem is that the IDs are numbered from 1 counting up for every new client, so a new project starts with at least ID 2. That means that `ipairs` skips the entire table and returns 0. `pairs` doesn't validate indices and just iterates over the table (see [here](https://stackoverflow.com/a/55109411)).

without the fix:

https://user-images.githubusercontent.com/5249233/150678850-b90b06d8-ca52-41ac-b563-dcb5d536cc64.mov

with the fix:

https://user-images.githubusercontent.com/5249233/150678998-0b563d26-71ea-458d-bb0e-54db73eb7275.mov


